### PR TITLE
fix non snake case warnings

### DIFF
--- a/src/curve/edwards/extended.rs
+++ b/src/curve/edwards/extended.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::constants::EDWARDS_D;
 use crate::curve::edwards::affine::AffinePoint;
 use crate::curve::montgomery::montgomery::MontgomeryPoint; // XXX: need to fix this path

--- a/src/curve/montgomery/montgomery.rs
+++ b/src/curve/montgomery/montgomery.rs
@@ -8,6 +8,8 @@
 // - Henry de Valence <hdevalence@hdevalence.ca>
 // - Kevaundray Wedderburn <kevtheappdev@gmail.com>
 
+#![allow(non_snake_case)]
+
 use crate::constants::A_PLUS_TWO_OVER_FOUR;
 use crate::curve::edwards::extended::ExtendedPoint;
 use crate::field::{FieldElement, Scalar};

--- a/src/curve/scalar_mul/double_base.rs
+++ b/src/curve/scalar_mul/double_base.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use super::double_and_add;
 use crate::constants::TWISTED_EDWARDS_BASE_POINT;
 use crate::curve::twedwards::extended::ExtendedPoint;

--- a/src/curve/scalar_mul/variable_base.rs
+++ b/src/curve/scalar_mul/variable_base.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use super::window::wnaf::LookupTable;
 use crate::curve::twedwards::{extended::ExtendedPoint, extensible::ExtensiblePoint};
 use crate::field::Scalar;

--- a/src/curve/scalar_mul/window/wnaf/mod.rs
+++ b/src/curve/scalar_mul/window/wnaf/mod.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::curve::twedwards::extended::ExtendedPoint;
 use crate::curve::twedwards::projective::ProjectiveNielsPoint;
 use subtle::{ConditionallySelectable, ConstantTimeEq};

--- a/src/curve/twedwards/extended.rs
+++ b/src/curve/twedwards/extended.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::constants::TWISTED_D;
 use crate::curve::edwards::ExtendedPoint as EdwardsExtendedPoint;
 use crate::curve::twedwards::affine::AffinePoint;

--- a/src/curve/twedwards/extensible.rs
+++ b/src/curve/twedwards/extensible.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::constants::{TWISTED_D, TWO_TIMES_TWISTED_D};
 use crate::curve::twedwards::{
     affine::AffineNielsPoint, extended::ExtendedPoint, projective::ProjectiveNielsPoint,

--- a/src/curve/twedwards/projective.rs
+++ b/src/curve/twedwards/projective.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::curve::twedwards::{extended::ExtendedPoint, extensible::ExtensiblePoint};
 use crate::field::FieldElement;
 use subtle::{Choice, ConditionallyNegatable, ConditionallySelectable};

--- a/src/decaf/decaf.rs
+++ b/src/decaf/decaf.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::constants::{DECAF_BASEPOINT, DECAF_FACTOR, NEG_EDWARDS_D, NEG_FOUR_TIMES_TWISTED_D};
 use crate::curve::twedwards::extended::ExtendedPoint;
 use crate::field::FieldElement;

--- a/src/ristretto/ristretto.rs
+++ b/src/ristretto/ristretto.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::curve::twedwards::extended::ExtendedPoint;
 use std::fmt;
 use subtle::{Choice, ConstantTimeEq};


### PR DESCRIPTION
I've added `#![allow(non_snake_case)]` in all modules that had non snake case warnings.