### PR TITLE
derive Hash for MontgomeryPoint

### DIFF
--- a/src/curve/montgomery/montgomery.rs
+++ b/src/curve/montgomery/montgomery.rs
@@ -37,7 +37,7 @@ const LOW_C: MontgomeryPoint = MontgomeryPoint([
     0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 ]);
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Hash)]
 #[cfg_attr(feature = "zeroize", derive(Zeroize))]
 pub struct MontgomeryPoint(pub [u8; 56]);
 


### PR DESCRIPTION
This could later allow users to store x448 public keys in a Hashtable.