### PR TITLE
fix bugs in ExtendedPoint::compress and decompress

### DIFF
--- a/src/decaf/decaf.rs
+++ b/src/decaf/decaf.rs
@@ -103,7 +103,7 @@ impl CompressedDecaf {
         let v = ss * (NEG_FOUR_TIMES_TWISTED_D) + u1_sqr; // XXX: constantify please
 
         let (I, ok) = (v * u1_sqr).inverse_square_root();
-        if !ok {
+        if ok.unwrap_u8() == 0 {
             return None;
         }
 


### PR DESCRIPTION
Fix these bugs:

- `compress()` was setting the low order bit instead of the high. From RFC 8032:

  >   To form the
  >   encoding of the point, copy the least significant bit of the
  >   x-coordinate to the most significant bit of the final octet.

- `decompress()` was incorrectly choosing the x value. While in curve25519-dalek the `sqrt_ratio_i` always returns the nonnegative square root, this is not true for this crate's `sqrt_ratio`.

  >  Otherwise, if x_0 != x mod 2, set x <-- p - x

- `decompress()` did not handle correctly the identity point. `sqrt_ratio` returned `is_err = 1` for it even if the sqrt is zero, which seems to be caused by the trick of multiplying by `u` (which does not work if it's 0). I think the implementation could follow RFC 8032 more closely in that part, but I wanted to get the simplest fix first.