### PR TITLE
Add Scalar methods and operators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ exclude = [
 
 [dependencies]
 subtle = "2.2.2"
+rand_core = { version = "0.6" }
 hex = "0.4"
 fiat-crypto = { version = "0.1.4", optional = true}
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,4 @@
-use crate::decaf::DecafPoint;
+use crate::{decaf::DecafPoint, Scalar};
 
 #[cfg(feature = "u32_backend")]
 pub(crate) use crate::field::u32::constants::*;
@@ -7,3 +7,12 @@ pub(crate) use crate::field::u32::constants::*;
 pub(crate) use crate::field::fiat_u64::constants::*;
 
 pub(crate) const DECAF_BASEPOINT: DecafPoint = DecafPoint(TWISTED_EDWARDS_BASE_POINT);
+
+/// `BASEPOINT_ORDER` is the order of the Ed448 basepoint, i.e.,
+/// $$
+/// \ell = 2^\{446\} + 0x8335dc163bb124b65129c96fde933d8d723a70aadc873d6d54a7bb0d.
+/// $$
+pub(crate) const BASEPOINT_ORDER: Scalar = Scalar([
+    0xab5844f3, 0x2378c292, 0x8dc58f55, 0x216cc272, 0xaed63690, 0xc44edb49, 0x7cca23e9, 0xffffffff,
+    0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0x3fffffff,
+]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
 #![forbid(unsafe_code)]
 // XXX: Change this to deny later on
 #![warn(unused_attributes, unused_imports, unused_mut, unused_must_use)]
+
+// Internal macros. Must come first!
+#[macro_use]
+pub(crate) mod macros;
+
 // As usual, we will use this file to carefully define the API/ what we expose to the user
 pub mod constants;
 pub mod curve;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,123 @@
+// -*- mode: rust; -*-
+//
+// This file is part of curve25519-dalek.
+// Copyright (c) 2016-2021 isis agora lovecruft
+// Copyright (c) 2016-2019 Henry de Valence
+// See LICENSE for licensing information.
+//
+// Authors:
+// - isis agora lovecruft <isis@patternsinthevoid.net>
+// - Henry de Valence <hdevalence@hdevalence.ca>
+
+//! Internal macros.
+
+/// Define borrow and non-borrow variants of `Add`.
+macro_rules! define_add_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> Add<&'b $rhs> for $lhs {
+            type Output = $out;
+            fn add(self, rhs: &'b $rhs) -> $out {
+                &self + rhs
+            }
+        }
+
+        impl<'a> Add<$rhs> for &'a $lhs {
+            type Output = $out;
+            fn add(self, rhs: $rhs) -> $out {
+                self + &rhs
+            }
+        }
+
+        impl Add<$rhs> for $lhs {
+            type Output = $out;
+            fn add(self, rhs: $rhs) -> $out {
+                &self + &rhs
+            }
+        }
+    };
+}
+
+/// Define non-borrow variants of `AddAssign`.
+macro_rules! define_add_assign_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty) => {
+        impl AddAssign<$rhs> for $lhs {
+            fn add_assign(&mut self, rhs: $rhs) {
+                *self += &rhs;
+            }
+        }
+    };
+}
+
+/// Define borrow and non-borrow variants of `Sub`.
+macro_rules! define_sub_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> Sub<&'b $rhs> for $lhs {
+            type Output = $out;
+            fn sub(self, rhs: &'b $rhs) -> $out {
+                &self - rhs
+            }
+        }
+
+        impl<'a> Sub<$rhs> for &'a $lhs {
+            type Output = $out;
+            fn sub(self, rhs: $rhs) -> $out {
+                self - &rhs
+            }
+        }
+
+        impl Sub<$rhs> for $lhs {
+            type Output = $out;
+            fn sub(self, rhs: $rhs) -> $out {
+                &self - &rhs
+            }
+        }
+    };
+}
+
+/// Define non-borrow variants of `SubAssign`.
+macro_rules! define_sub_assign_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty) => {
+        impl SubAssign<$rhs> for $lhs {
+            fn sub_assign(&mut self, rhs: $rhs) {
+                *self -= &rhs;
+            }
+        }
+    };
+}
+
+/// Define borrow and non-borrow variants of `Mul`.
+macro_rules! define_mul_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty, Output = $out:ty) => {
+        impl<'b> Mul<&'b $rhs> for $lhs {
+            type Output = $out;
+            fn mul(self, rhs: &'b $rhs) -> $out {
+                &self * rhs
+            }
+        }
+
+        impl<'a> Mul<$rhs> for &'a $lhs {
+            type Output = $out;
+            fn mul(self, rhs: $rhs) -> $out {
+                self * &rhs
+            }
+        }
+
+        impl Mul<$rhs> for $lhs {
+            type Output = $out;
+            fn mul(self, rhs: $rhs) -> $out {
+                &self * &rhs
+            }
+        }
+    };
+}
+
+/// Define non-borrow variants of `MulAssign`.
+macro_rules! define_mul_assign_variants {
+    (LHS = $lhs:ty, RHS = $rhs:ty) => {
+        impl MulAssign<$rhs> for $lhs {
+            fn mul_assign(&mut self, rhs: $rhs) {
+                *self *= &rhs;
+            }
+        }
+    };
+}


### PR DESCRIPTION
This is on top of #22 so it's including the fixes there.

This adds code required to use this crate with https://github.com/ZcashFoundation/frost/ 

- `Scalar::from_canonical_bytes`
- `Scalar::bytes_mod_order_wide` which is required by
- `Scalar::random`
- Operators, with code lifted from curve25519-dalek.
