### PR TITLE
Some "cleanup" works

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [".gitignore", ".github/*"]
 
 [dependencies]
 subtle = "2.2.2"
-rand_core = { version = "0.6" }
+rand_core = { version = "0.6", optional = true }
 hex = "0.4"
 fiat-crypto = { version = "0.1.4", optional = true }
 
@@ -30,3 +30,4 @@ optional = true
 default = ["fiat_u64_backend"]
 fiat_u64_backend = ["fiat-crypto"]
 u32_backend = []
+rand = ["rand_core"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ exclude = [".gitignore", ".github/*"]
 [dependencies]
 subtle = "2.2.2"
 rand_core = { version = "0.6", optional = true }
-hex = "0.4"
 fiat-crypto = { version = "0.1.4", optional = true }
 
 [dependencies.zeroize]
@@ -31,3 +30,6 @@ default = ["fiat_u64_backend"]
 fiat_u64_backend = ["fiat-crypto"]
 u32_backend = []
 rand = ["rand_core"]
+
+[dev-dependencies]
+hex-literal = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ed448-goldilocks"
 version = "0.9.0"
 authors = ["Kevaundray Wedderburn <kevtheappdev@gmail.com>"]
-edition = "2018"
+edition = "2021"
 readme = "README.md"
 license = "BSD-3-Clause"
 repository = "https://github.com/crate-crypto/Ed448-Goldilocks"

--- a/src/curve/edwards/extended.rs
+++ b/src/curve/edwards/extended.rs
@@ -417,18 +417,17 @@ mod tests {
     use hex_literal::hex;
     use super::*;
 
-    macro_rules! hex2field {
-        ($data:literal) => {{
-            let mut bytes = hex!($data);
-            bytes.reverse();
-            FieldElement::from_bytes(&bytes)
-        }};
+    fn hex_to_field(hex: &'static str) -> FieldElement {
+        assert_eq!(hex.len(), 56 * 2);
+        let mut bytes = hex_literal::decode(&[hex.as_bytes()]);
+        bytes.reverse();
+        FieldElement::from_bytes(&bytes)
     }
 
     #[test]
     fn test_isogeny() {
-        let x = hex2field!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
-        let y = hex2field!("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
+        let x = hex_to_field("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
+        let y = hex_to_field("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
         let a = AffinePoint { x, y }.to_extended();
         let twist_a = a.to_twisted().to_untwisted();
         assert!(twist_a == a.double().double())
@@ -440,13 +439,13 @@ mod tests {
         use crate::constants::{GOLDILOCKS_BASE_POINT, TWISTED_EDWARDS_BASE_POINT};
 
         // This was the original basepoint which had order 2q;
-        let old_x = hex2field!("4F1970C66BED0DED221D15A622BF36DA9E146570470F1767EA6DE324A3D3A46412AE1AF72AB66511433B80E18B00938E2626A82BC70CC05E");
-        let old_y = hex2field!("693F46716EB6BC248876203756C9C7624BEA73736CA3984087789C1E05A0C2D73AD3FF1CE67C39C4FDBD132C4ED7C8AD9808795BF230FA14");
+        let old_x = hex_to_field("4F1970C66BED0DED221D15A622BF36DA9E146570470F1767EA6DE324A3D3A46412AE1AF72AB66511433B80E18B00938E2626A82BC70CC05E");
+        let old_y = hex_to_field("693F46716EB6BC248876203756C9C7624BEA73736CA3984087789C1E05A0C2D73AD3FF1CE67C39C4FDBD132C4ED7C8AD9808795BF230FA14");
         let old_bp = AffinePoint { x: old_x, y: old_y }.to_extended();
 
         // This is the new basepoint, that is in the ed448 paper
-        let new_x = hex2field!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
-        let new_y = hex2field!("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
+        let new_x = hex_to_field("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
+        let new_y = hex_to_field("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
         let new_bp = AffinePoint { x: new_x, y: new_y }.to_extended();
 
         // Doubling the old basepoint, should give us the new basepoint
@@ -463,15 +462,15 @@ mod tests {
 
     #[test]
     fn test_is_on_curve() {
-        let x  = hex2field!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
-        let y  = hex2field!("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
+        let x = hex_to_field("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
+        let y = hex_to_field("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
         let gen = AffinePoint { x, y }.to_extended();
         assert!(gen.is_on_curve());
     }
     #[test]
     fn test_compress_decompress() {
-        let x  = hex2field!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
-        let y  = hex2field!("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
+        let x = hex_to_field("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
+        let y = hex_to_field("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
         let gen = AffinePoint { x, y }.to_extended();
 
         let decompressed_point = gen.compress().decompress();
@@ -495,15 +494,15 @@ mod tests {
         let compressed = CompressedEdwardsY(bytes);
         let decompressed = compressed.decompress().unwrap();
 
-        assert_eq!(decompressed.X, hex2field!("39c41cea305d737df00de8223a0d5f4d48c8e098e16e9b4b2f38ac353262e119cb5ff2afd6d02464702d9d01c9921243fc572f9c718e2527"));
-        assert_eq!(decompressed.Y, hex2field!("a7ad5629142315c3c03730ab126380eb99a33cf01d06dfc3cf8ca3ae66bde9dc2d6d74f3dd3d05e1d41fd0233f032d967d8909b1536a9c64"));
+        assert_eq!(decompressed.X, hex_to_field("39c41cea305d737df00de8223a0d5f4d48c8e098e16e9b4b2f38ac353262e119cb5ff2afd6d02464702d9d01c9921243fc572f9c718e2527"));
+        assert_eq!(decompressed.Y, hex_to_field("a7ad5629142315c3c03730ab126380eb99a33cf01d06dfc3cf8ca3ae66bde9dc2d6d74f3dd3d05e1d41fd0233f032d967d8909b1536a9c64"));
 
         let bytes = hex!("010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
         let compressed = CompressedEdwardsY(bytes);
         let decompressed = compressed.decompress().unwrap();
 
-        assert_eq!(decompressed.X, hex2field!("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
-        assert_eq!(decompressed.Y, hex2field!("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"));
+        assert_eq!(decompressed.X, hex_to_field("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+        assert_eq!(decompressed.Y, hex_to_field("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"));
     }
     #[test]
     fn test_is_torsion_free() {

--- a/src/curve/edwards/extended.rs
+++ b/src/curve/edwards/extended.rs
@@ -416,7 +416,6 @@ impl<'a, 'b> Mul<&'b ExtendedPoint> for &'a Scalar {
 mod tests {
     use hex_literal::hex;
     use super::*;
-    use std::convert::TryInto;
 
     macro_rules! hex2field {
         ($data:literal) => {{

--- a/src/curve/edwards/extended.rs
+++ b/src/curve/edwards/extended.rs
@@ -414,31 +414,22 @@ impl<'a, 'b> Mul<&'b ExtendedPoint> for &'a Scalar {
 
 #[cfg(test)]
 mod tests {
+    use hex_literal::hex;
     use super::*;
-    use hex::decode as hex_decode;
     use std::convert::TryInto;
-    fn slice_to_fixed_array(b: &[u8]) -> [u8; 56] {
-        let mut a: [u8; 56] = [0; 56];
-        a.copy_from_slice(&b);
-        a
-    }
 
-    fn hex_to_field(data: &str) -> FieldElement {
-        let mut bytes = hex_decode(data).unwrap();
-        bytes.reverse();
-        FieldElement::from_bytes(&slice_to_fixed_array(&bytes))
-    }
-
-    fn field_to_hex(f: &FieldElement) -> String {
-        let mut buf = f.to_bytes();
-        buf.reverse();
-        hex::encode(buf)
+    macro_rules! hex2field {
+        ($data:literal) => {{
+            let mut bytes = hex!($data);
+            bytes.reverse();
+            FieldElement::from_bytes(&bytes)
+        }};
     }
 
     #[test]
     fn test_isogeny() {
-        let x = hex_to_field("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
-        let y = hex_to_field("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
+        let x = hex2field!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
+        let y = hex2field!("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
         let a = AffinePoint { x, y }.to_extended();
         let twist_a = a.to_twisted().to_untwisted();
         assert!(twist_a == a.double().double())
@@ -450,13 +441,13 @@ mod tests {
         use crate::constants::{GOLDILOCKS_BASE_POINT, TWISTED_EDWARDS_BASE_POINT};
 
         // This was the original basepoint which had order 2q;
-        let old_x = hex_to_field("4F1970C66BED0DED221D15A622BF36DA9E146570470F1767EA6DE324A3D3A46412AE1AF72AB66511433B80E18B00938E2626A82BC70CC05E");
-        let old_y = hex_to_field("693F46716EB6BC248876203756C9C7624BEA73736CA3984087789C1E05A0C2D73AD3FF1CE67C39C4FDBD132C4ED7C8AD9808795BF230FA14");
+        let old_x = hex2field!("4F1970C66BED0DED221D15A622BF36DA9E146570470F1767EA6DE324A3D3A46412AE1AF72AB66511433B80E18B00938E2626A82BC70CC05E");
+        let old_y = hex2field!("693F46716EB6BC248876203756C9C7624BEA73736CA3984087789C1E05A0C2D73AD3FF1CE67C39C4FDBD132C4ED7C8AD9808795BF230FA14");
         let old_bp = AffinePoint { x: old_x, y: old_y }.to_extended();
 
         // This is the new basepoint, that is in the ed448 paper
-        let new_x = hex_to_field("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
-        let new_y = hex_to_field("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
+        let new_x = hex2field!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
+        let new_y = hex2field!("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
         let new_bp = AffinePoint { x: new_x, y: new_y }.to_extended();
 
         // Doubling the old basepoint, should give us the new basepoint
@@ -473,15 +464,15 @@ mod tests {
 
     #[test]
     fn test_is_on_curve() {
-        let x  = hex_to_field("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
-        let y  = hex_to_field("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
+        let x  = hex2field!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
+        let y  = hex2field!("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
         let gen = AffinePoint { x, y }.to_extended();
         assert!(gen.is_on_curve());
     }
     #[test]
     fn test_compress_decompress() {
-        let x  = hex_to_field("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
-        let y  = hex_to_field("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
+        let x  = hex2field!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
+        let y  = hex2field!("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
         let gen = AffinePoint { x, y }.to_extended();
 
         let decompressed_point = gen.compress().decompress();
@@ -491,7 +482,7 @@ mod tests {
     }
     #[test]
     fn test_decompress_compress() {
-        let bytes: [u8; 57] = hex::decode("649c6a53b109897d962d033f23d01fd4e1053dddf3746d2ddce9bd66aea38ccfc3df061df03ca399eb806312ab3037c0c31523142956ada780").unwrap().try_into().unwrap();
+        let bytes = hex!("649c6a53b109897d962d033f23d01fd4e1053dddf3746d2ddce9bd66aea38ccfc3df061df03ca399eb806312ab3037c0c31523142956ada780");
         let compressed = CompressedEdwardsY(bytes);
         let decompressed = compressed.decompress().unwrap();
 
@@ -501,26 +492,26 @@ mod tests {
     }
     #[test]
     fn test_just_decompress() {
-        let bytes: [u8; 57] = hex::decode("649c6a53b109897d962d033f23d01fd4e1053dddf3746d2ddce9bd66aea38ccfc3df061df03ca399eb806312ab3037c0c31523142956ada780").unwrap().try_into().unwrap();
+        let bytes = hex!("649c6a53b109897d962d033f23d01fd4e1053dddf3746d2ddce9bd66aea38ccfc3df061df03ca399eb806312ab3037c0c31523142956ada780");
         let compressed = CompressedEdwardsY(bytes);
         let decompressed = compressed.decompress().unwrap();
 
-        assert_eq!(field_to_hex(&decompressed.X), "39c41cea305d737df00de8223a0d5f4d48c8e098e16e9b4b2f38ac353262e119cb5ff2afd6d02464702d9d01c9921243fc572f9c718e2527");
-        assert_eq!(field_to_hex(&decompressed.Y), "a7ad5629142315c3c03730ab126380eb99a33cf01d06dfc3cf8ca3ae66bde9dc2d6d74f3dd3d05e1d41fd0233f032d967d8909b1536a9c64");
+        assert_eq!(decompressed.X, hex2field!("39c41cea305d737df00de8223a0d5f4d48c8e098e16e9b4b2f38ac353262e119cb5ff2afd6d02464702d9d01c9921243fc572f9c718e2527"));
+        assert_eq!(decompressed.Y, hex2field!("a7ad5629142315c3c03730ab126380eb99a33cf01d06dfc3cf8ca3ae66bde9dc2d6d74f3dd3d05e1d41fd0233f032d967d8909b1536a9c64"));
 
-        let bytes: [u8; 57] = hex::decode("010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000").unwrap().try_into().unwrap();
+        let bytes = hex!("010000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
         let compressed = CompressedEdwardsY(bytes);
         let decompressed = compressed.decompress().unwrap();
 
-        assert_eq!(field_to_hex(&decompressed.X), "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000");
-        assert_eq!(field_to_hex(&decompressed.Y), "0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001");
+        assert_eq!(decompressed.X, hex2field!("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"));
+        assert_eq!(decompressed.Y, hex2field!("0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001"));
     }
     #[test]
     fn test_is_torsion_free() {
         assert!(ExtendedPoint::generator().is_torsion_free());
         assert!(ExtendedPoint::identity().is_torsion_free());
 
-        let bytes: [u8; 57] = hex::decode("13b6714c7a5f53101bbec88f2f17cd30f42e37fae363a5474efb4197ed6005df5861ae178a0c2c16ad378b7befed0d0904b7ced35e9f674180").unwrap().try_into().unwrap();
+        let bytes = hex!("13b6714c7a5f53101bbec88f2f17cd30f42e37fae363a5474efb4197ed6005df5861ae178a0c2c16ad378b7befed0d0904b7ced35e9f674180");
         let compressed = CompressedEdwardsY(bytes);
         let decompressed = compressed.decompress().unwrap();
         assert!(!decompressed.is_torsion_free());

--- a/src/curve/twedwards/extended.rs
+++ b/src/curve/twedwards/extended.rs
@@ -170,24 +170,22 @@ impl ExtendedPoint {
 }
 #[cfg(test)]
 mod tests {
+    use hex_literal::hex;
     use super::*;
     use crate::constants::{GOLDILOCKS_BASE_POINT, TWISTED_EDWARDS_BASE_POINT};
-    use hex::decode as hex_decode;
-    fn slice_to_fixed_array(b: &[u8]) -> [u8; 56] {
-        let mut a: [u8; 56] = [0; 56];
-        a.copy_from_slice(&b);
-        a
+
+    macro_rules! hex2field {
+        ($data:literal) => {{
+            let mut bytes = hex!($data);
+            bytes.reverse();
+            FieldElement::from_bytes(&bytes)
+        }};
     }
 
-    fn hex_to_field(data: &str) -> FieldElement {
-        let mut bytes = hex_decode(data).unwrap();
-        bytes.reverse();
-        FieldElement::from_bytes(&slice_to_fixed_array(&bytes))
-    }
     #[test]
     fn test_isogeny() {
-        let x  = hex_to_field("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
-        let y  = hex_to_field("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
+        let x  = hex2field!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
+        let y  = hex2field!("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
         let a = AffinePoint { x, y }.to_extended();
         let twist_a = a.to_untwisted().to_twisted();
         assert!(twist_a == a.double().double())

--- a/src/curve/twedwards/extended.rs
+++ b/src/curve/twedwards/extended.rs
@@ -170,22 +170,20 @@ impl ExtendedPoint {
 }
 #[cfg(test)]
 mod tests {
-    use hex_literal::hex;
     use super::*;
     use crate::constants::{GOLDILOCKS_BASE_POINT, TWISTED_EDWARDS_BASE_POINT};
 
-    macro_rules! hex2field {
-        ($data:literal) => {{
-            let mut bytes = hex!($data);
-            bytes.reverse();
-            FieldElement::from_bytes(&bytes)
-        }};
+    fn hex_to_field(hex: &'static str) -> FieldElement {
+        assert_eq!(hex.len(), 56 * 2);
+        let mut bytes = hex_literal::decode(&[hex.as_bytes()]);
+        bytes.reverse();
+        FieldElement::from_bytes(&bytes)
     }
 
     #[test]
     fn test_isogeny() {
-        let x  = hex2field!("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
-        let y  = hex2field!("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
+        let x = hex_to_field("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa955555555555555555555555555555555555555555555555555555555");
+        let y = hex_to_field("ae05e9634ad7048db359d6205086c2b0036ed7a035884dd7b7e36d728ad8c4b80d6565833a2a3098bbbcb2bed1cda06bdaeafbcdea9386ed");
         let a = AffinePoint { x, y }.to_extended();
         let twist_a = a.to_untwisted().to_twisted();
         assert!(twist_a == a.double().double())

--- a/src/field/scalar.rs
+++ b/src/field/scalar.rs
@@ -435,8 +435,6 @@ fn montgomery_multiply(x: &Scalar, y: &Scalar) -> Scalar {
 }
 #[cfg(test)]
 mod test {
-    use std::convert::TryInto;
-
     use hex_literal::hex;
     use super::*;
 

--- a/src/field/scalar.rs
+++ b/src/field/scalar.rs
@@ -1,5 +1,6 @@
 use std::ops::{Add, Index, IndexMut, Mul, Sub};
 
+#[cfg(feature = "rand")]
 use rand_core::{CryptoRng, RngCore};
 use subtle::{Choice, ConstantTimeEq};
 
@@ -333,6 +334,7 @@ impl Scalar {
     /// # Returns
     ///
     /// A random scalar within ℤ/lℤ.
+    #[cfg(feature = "rand")]
     pub fn random<R: RngCore + CryptoRng>(rng: &mut R) -> Self {
         let mut scalar_bytes = [0u8; 114];
         rng.fill_bytes(&mut scalar_bytes);

--- a/src/field/scalar.rs
+++ b/src/field/scalar.rs
@@ -437,7 +437,9 @@ fn montgomery_multiply(x: &Scalar, y: &Scalar) -> Scalar {
 mod test {
     use std::convert::TryInto;
 
+    use hex_literal::hex;
     use super::*;
+
     #[test]
     fn test_basic_add() {
         let five = Scalar::from(5);
@@ -553,19 +555,19 @@ mod test {
     #[test]
     fn test_from_canonical_bytes() {
         // ff..ff should fail
-        let mut bytes: [u8; 57] = hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap().try_into().unwrap();
+        let mut bytes: [u8; 57] = hex!("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         bytes.reverse();
         let s = Scalar::from_canonical_bytes(bytes);
         assert_eq!(s, None);
 
         // n should fail
-        let mut bytes: [u8; 57] = hex::decode("003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f3").unwrap().try_into().unwrap();
+        let mut bytes: [u8; 57] = hex!("003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f3");
         bytes.reverse();
         let s = Scalar::from_canonical_bytes(bytes);
         assert_eq!(s, None);
 
         // n-1 should work
-        let mut bytes: [u8; 57] = hex::decode("003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f2").unwrap().try_into().unwrap();
+        let mut bytes: [u8; 57] = hex!("003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f2");
         bytes.reverse();
         let s = Scalar::from_canonical_bytes(bytes);
         match s {
@@ -577,28 +579,28 @@ mod test {
     #[test]
     fn test_from_bytes_mod_order_wide() {
         // n should become 0
-        let mut bytes: [u8; 114] = hex::decode("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f3").unwrap().try_into().unwrap();
+        let mut bytes: [u8; 114] = hex!("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f3");
         bytes.reverse();
         let s = Scalar::from_bytes_mod_order_wide(&bytes);
         assert_eq!(s, Scalar::zero());
 
         // n-1 should stay the same
-        let mut bytes: [u8; 114] = hex::decode("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f2").unwrap().try_into().unwrap();
+        let mut bytes: [u8; 114] = hex!("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f2");
         bytes.reverse();
         let s = Scalar::from_bytes_mod_order_wide(&bytes);
         assert_eq!(s, Scalar::zero() - Scalar::one());
 
         // n+1 should become 1
-        let mut bytes: [u8; 114] = hex::decode("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f4").unwrap().try_into().unwrap();
+        let mut bytes: [u8; 114] = hex!("000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f4");
         bytes.reverse();
         let s = Scalar::from_bytes_mod_order_wide(&bytes);
         assert_eq!(s, Scalar::one());
 
         // 2^912-1 should become 0x2939f823b7292052bcb7e4d070af1a9cc14ba3c47c44ae17cf72c985bb24b6c520e319fb37a63e29800f160787ad1d2e11883fa931e7de81
-        let mut bytes: [u8; 114] = hex::decode("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff").unwrap().try_into().unwrap();
+        let mut bytes: [u8; 114] = hex!("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         bytes.reverse();
         let s = Scalar::from_bytes_mod_order_wide(&bytes);
-        let mut bytes: [u8; 57] = hex::decode("002939f823b7292052bcb7e4d070af1a9cc14ba3c47c44ae17cf72c985bb24b6c520e319fb37a63e29800f160787ad1d2e11883fa931e7de81").unwrap().try_into().unwrap();
+        let mut bytes: [u8; 57] = hex!("002939f823b7292052bcb7e4d070af1a9cc14ba3c47c44ae17cf72c985bb24b6c520e319fb37a63e29800f160787ad1d2e11883fa931e7de81");
         bytes.reverse();
         let reduced = Scalar::from_canonical_bytes(bytes).unwrap();
         assert_eq!(s, reduced);
@@ -607,7 +609,7 @@ mod test {
     #[test]
     fn test_to_bytes_rfc8032() {
         // n-1
-        let mut bytes: [u8; 57] = hex::decode("003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f2").unwrap().try_into().unwrap();
+        let mut bytes: [u8; 57] = hex!("003fffffffffffffffffffffffffffffffffffffffffffffffffffffff7cca23e9c44edb49aed63690216cc2728dc58f552378c292ab5844f2");
         bytes.reverse();
         let x = Scalar::zero() - Scalar::one();
         let candidate = x.to_bytes_rfc_8032();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![forbid(unsafe_code)]
 // XXX: Change this to deny later on
 #![warn(unused_attributes, unused_imports, unused_mut, unused_must_use)]
+#![allow(non_snake_case)]
 
 // Internal macros. Must come first!
 #[macro_use]


### PR DESCRIPTION
Including creating a feature for `rand_core`, use `hex-literal` rather than `hex` in test cases and make it `dev-dependencies`, bump to version 2021 (removing `use std::convert::TryInto;`s), add lint `#![allow(non_snake_case)]` for upper case point variable names.