### PR TITLE
remove asserts that could leak timing information (credits to @pornin)

### DIFF
--- a/src/field/scalar.rs
+++ b/src/field/scalar.rs
@@ -384,7 +384,6 @@ fn sub_extra(a: &Scalar, b: &Scalar, carry: u32) -> Scalar {
     // Since the borrow should never be more than 0, the carry should never be more than 1;
     // XXX: Explain why the case of borrow == 1 should never happen
     let borrow = chain + (carry as i64);
-    assert!(borrow == -1 || borrow == 0);
 
     chain = 0i64;
     for i in 0..14 {

--- a/src/field/u32/prime_field.rs
+++ b/src/field/u32/prime_field.rs
@@ -326,9 +326,7 @@ impl FieldElement28 {
         // If the value was more than p, then the final borrow will be zero. This is scarry.
         // Case 2:
         // If the  value was less than p, the final borrow will be -1.
-
-        // The only two possibilities for the borrow bit is -1 or 0.
-        assert!(scarry == 0 || scarry + 1 == 0);
+        // Thus the only two possibilities for the borrow bit is -1 or 0.
 
         let scarry_mask = (scarry as u32) & MASK;
         let mut carry = 0u64;


### PR DESCRIPTION
Closes #30 by simply removing the asserts.

I tried to expand the comment in `scalar.rs` to justify why borrow would never be 1, but got stuck at trying to find a case where `carry` would be 1 in the first place... So I just gave up on that for now.