### PR TITLE
use stack for table in Scalar::invert() to prevent leaking values to the heap (credits to @pornin)

### DIFF
--- a/src/field/scalar.rs
+++ b/src/field/scalar.rs
@@ -179,7 +179,7 @@ impl Scalar {
         montgomery_multiply(&self, &self)
     }
     pub fn invert(&self) -> Self {
-        let mut pre_comp: Vec<Scalar> = vec![Scalar::zero(); 8];
+        let mut pre_comp = [Scalar::zero(); 8];
         let mut result = Scalar::zero();
 
         let scalar_window_bits = 3;


### PR DESCRIPTION
Closes #32 by allocating the table in stack.