### PR TITLE
feat: Adapt to new types introduced in fiat-crypto 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [".gitignore", ".github/*"]
 [dependencies]
 subtle = "2.2.2"
 rand_core = { version = "0.6", optional = true }
-fiat-crypto = { version = "0.1.4", optional = true }
+fiat-crypto = { version = "0.2.0", optional = true }
 
 [dependencies.zeroize]
 version = "1"

--- a/src/field/fiat_u64/constants.rs
+++ b/src/field/fiat_u64/constants.rs
@@ -1,3 +1,5 @@
+use fiat_crypto::p448_solinas_64::fiat_p448_tight_field_element;
+
 // Move all curve specific constants into this file
 // as they will have different representations depending on the backend
 use crate::curve::edwards::ExtendedPoint;
@@ -5,19 +7,20 @@ use crate::curve::twedwards::extended::ExtendedPoint as TwExtendedPoint;
 use crate::field::fiat_u64::FieldElement56;
 
 /// -4 * Twisted_D = -4 * (EDWARDS_D-1)
-pub const NEG_FOUR_TIMES_TWISTED_D: FieldElement56 = FieldElement56([
-    156327,
-    0,
-    0,
-    0,
-    72057594037927935,
-    72057594037927935,
-    72057594037927935,
-    72057594037927935,
-]);
+pub const NEG_FOUR_TIMES_TWISTED_D: FieldElement56 =
+    FieldElement56(fiat_p448_tight_field_element([
+        156327,
+        0,
+        0,
+        0,
+        72057594037927935,
+        72057594037927935,
+        72057594037927935,
+        72057594037927935,
+    ]));
 
 /// Edwards `d`, equals to -39081
-pub const EDWARDS_D: FieldElement56 = FieldElement56([
+pub const EDWARDS_D: FieldElement56 = FieldElement56(fiat_p448_tight_field_element([
     144115188075816789,
     144115188075855870,
     144115188075855870,
@@ -26,13 +29,14 @@ pub const EDWARDS_D: FieldElement56 = FieldElement56([
     144115188075855870,
     144115188075855870,
     144115188075855870,
-]);
+]));
 
 /// Neg_Edwards `-d`, equals to 39081
-pub const NEG_EDWARDS_D: FieldElement56 = FieldElement56([39081, 0, 0, 0, 0, 0, 0, 0]);
+pub const NEG_EDWARDS_D: FieldElement56 =
+    FieldElement56(fiat_p448_tight_field_element([39081, 0, 0, 0, 0, 0, 0, 0]));
 
 /// Twisted Edwards D equals `d-1`, equals to -39082
-pub const TWISTED_D: FieldElement56 = FieldElement56([
+pub const TWISTED_D: FieldElement56 = FieldElement56(fiat_p448_tight_field_element([
     144115188075816788,
     144115188075855870,
     144115188075855870,
@@ -41,10 +45,10 @@ pub const TWISTED_D: FieldElement56 = FieldElement56([
     144115188075855870,
     144115188075855870,
     144115188075855870,
-]);
+]));
 
 /// Twice the Twisted Edwards d which equals to -78164
-pub const TWO_TIMES_TWISTED_D: FieldElement56 = FieldElement56([
+pub const TWO_TIMES_TWISTED_D: FieldElement56 = FieldElement56(fiat_p448_tight_field_element([
     144115188075777706,
     144115188075855870,
     144115188075855870,
@@ -53,10 +57,10 @@ pub const TWO_TIMES_TWISTED_D: FieldElement56 = FieldElement56([
     144115188075855870,
     144115188075855870,
     144115188075855870,
-]);
+]));
 
 /// INVSQRT(a*d_2-1) where d_2 = 39082/39081
-pub const DECAF_FACTOR: FieldElement56 = FieldElement56([
+pub const DECAF_FACTOR: FieldElement56 = FieldElement56(fiat_p448_tight_field_element([
     0x42ef0f45572736,
     0x7bf6aa20ce5296,
     0xf4fd6eded26033,
@@ -65,14 +69,15 @@ pub const DECAF_FACTOR: FieldElement56 = FieldElement56([
     0x6aa0a1f1a7b8a5,
     0x683bf68d722fa2,
     0x22d962fbeb24f7,
-]);
+]));
 
 /// 39082 used in the doubling procedure in montgomery ladder
-pub const A_PLUS_TWO_OVER_FOUR: FieldElement56 = FieldElement56([39082, 0, 0, 0, 0, 0, 0, 0]);
+pub const A_PLUS_TWO_OVER_FOUR: FieldElement56 =
+    FieldElement56(fiat_p448_tight_field_element([39082, 0, 0, 0, 0, 0, 0, 0]));
 
 /// The basepoint of Ed448-Goldilocks
 pub const GOLDILOCKS_BASE_POINT: ExtendedPoint = ExtendedPoint {
-    X: FieldElement56([
+    X: FieldElement56(fiat_p448_tight_field_element([
         10880955091566686,
         36276784145337894,
         69571282115576635,
@@ -81,8 +86,8 @@ pub const GOLDILOCKS_BASE_POINT: ExtendedPoint = ExtendedPoint {
         15440021224255559,
         66747077793030847,
         22264495316135181,
-    ]),
-    Y: FieldElement56([
+    ])),
+    Y: FieldElement56(fiat_p448_tight_field_element([
         2385235625966100,
         5396741696826776,
         8134720567442877,
@@ -91,9 +96,9 @@ pub const GOLDILOCKS_BASE_POINT: ExtendedPoint = ExtendedPoint {
         56121598560924524,
         10283140089599689,
         29624444337960636,
-    ]),
-    Z: FieldElement56([1, 0, 0, 0, 0, 0, 0, 0]),
-    T: FieldElement56([
+    ])),
+    Z: FieldElement56(fiat_p448_tight_field_element([1, 0, 0, 0, 0, 0, 0, 0])),
+    T: FieldElement56(fiat_p448_tight_field_element([
         1796939199780339,
         45174008172060139,
         40732174862907279,
@@ -102,12 +107,12 @@ pub const GOLDILOCKS_BASE_POINT: ExtendedPoint = ExtendedPoint {
         41035719659624511,
         30626637035688077,
         56117654178374172,
-    ]),
+    ])),
 };
 
 /// The basepoint of the Twisted Edwards curve which is 2-isogenous to Ed448-Goldilocks
 pub const TWISTED_EDWARDS_BASE_POINT: TwExtendedPoint = TwExtendedPoint {
-    X: FieldElement56([
+    X: FieldElement56(fiat_p448_tight_field_element([
         0,
         72057594037927936,
         72057594037927935,
@@ -116,8 +121,8 @@ pub const TWISTED_EDWARDS_BASE_POINT: TwExtendedPoint = TwExtendedPoint {
         72057594037927935,
         72057594037927935,
         36028797018963967,
-    ]),
-    Y: FieldElement56([
+    ])),
+    Y: FieldElement56(fiat_p448_tight_field_element([
         27155415521118820,
         3410937204744648,
         19376965222209947,
@@ -126,9 +131,9 @@ pub const TWISTED_EDWARDS_BASE_POINT: TwExtendedPoint = TwExtendedPoint {
         10141917371396176,
         59827755213158602,
         37445921829569158,
-    ]),
-    Z: FieldElement56([1, 0, 0, 0, 0, 0, 0, 0]),
-    T: FieldElement56([
+    ])),
+    Z: FieldElement56(fiat_p448_tight_field_element([1, 0, 0, 0, 0, 0, 0, 0])),
+    T: FieldElement56(fiat_p448_tight_field_element([
         64114820220813573,
         27592348249940115,
         21918321435874307,
@@ -137,5 +142,5 @@ pub const TWISTED_EDWARDS_BASE_POINT: TwExtendedPoint = TwExtendedPoint {
         63575698147485199,
         22766751209138687,
         30740600843388580,
-    ]),
+    ])),
 };


### PR DESCRIPTION
I have an outstanding PR that proposes some breaking changes to fiat-crypto, see mit-plv/fiat-crypto#1623. Briefly, it introduces new structures to replace type aliases, to prevent misuse of functions with different preconditions on their inputs' ranges. I'm opening this PR for a future upgrade early, with a `[patch.crates-io]` stanza, to kick the tires on the breaking change, and for temporary use in fiat-crypto integration tests. If this looks good, I can back out the patch stanza when `fiat-crypto` is released and mark it ready for review.